### PR TITLE
Make email optional to support anonymous auth

### DIFF
--- a/Sources/FirebaseJWTMiddleware/FirebaseJWTPayload.swift
+++ b/Sources/FirebaseJWTMiddleware/FirebaseJWTPayload.swift
@@ -11,9 +11,9 @@ public struct FirebaseJWTPayload: JWTPayload {
     var issuer: IssuerClaim
     var issuedAt: IssuedAtClaim
     var expirationAt: ExpirationClaim
-    public var email: String
     public var userID: String
     
+    public var email: String?
     public var picture: String?
     public var name: String?
     public var authTime: Date?


### PR DESCRIPTION
When using [Anonymous Login](https://firebase.google.com/docs/auth/ios/anonymous-auth), JSON decoding of the FirebaseJWTPayload was failing because `email` is a required property. This will likely also fail when using [Phone Number Login](https://firebase.google.com/docs/auth/ios/phone-auth), but I haven't verified this.

Thank you for a really useful and nicely implemented middleware!
